### PR TITLE
Connects to #31. Fields required to display segregation LOD score data due to revised SOP.

### DIFF
--- a/json-structure-phase1/Gene Curation Interface/gci-sop-v5.json
+++ b/json-structure-phase1/Gene Curation Interface/gci-sop-v5.json
@@ -153,8 +153,12 @@
                     {
                         "EvidenceOfSegregationInOneOrMoreFamilies": 
                         {
-                            "Value": "0.25",
-                            "Tally": "0.25",
+                            "PointsCounted": "2",
+                            "LodScoreTotal": "4.65",
+                            "LodScoreSumOfCandidateSequencingMethod": "1.2",
+                            "LodScoreSumOfExomeSequencingMethod": "3.45",
+                            "FamilyCountOfCandidateSequencingMethod": "1",
+                            "FamilyCountOfExomeSequencingMethod": "2",
                             "1": 
                             {
                                 "Evidence": 


### PR DESCRIPTION
I am proposing the following 5 new fields:
```
"LodScoreTotal"
"LodScoreSumOfCandidateSequencingMethod"
"LodScoreSumOfExomeSequencingMethod"
"FamilyCountOfCandidateSequencingMethod"
"FamilyCountOfExomeSequencingMethod"
```

Furthermore, given the revised segregation scoring logic, I think the `"Tally"` field is no longer appropriate. So I am proposing to remove the `"Tally"` field, and rename the `"Value"` field to the following:
```
"PointsCounted"
```